### PR TITLE
Enable ARM builds for linux via emulation

### DIFF
--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -43,6 +43,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Allows building non-amd64 wheels on Linux.
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+    
       - uses: actions/setup-python@v2
 
       - name: Install cibuildwheel
@@ -53,6 +60,7 @@ jobs:
           CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
           CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ARCHS_LINUX: "auto aarch64"
         run: python -m cibuildwheel --output-dir wheelhouse 
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/upload-to-test-pypi.yml
+++ b/.github/workflows/upload-to-test-pypi.yml
@@ -42,6 +42,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+          
       - uses: actions/setup-python@v2
 
       - name: Install cibuildwheel
@@ -52,6 +58,7 @@ jobs:
           CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
           CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ARCHS_LINUX: "auto aarch64"
         run: python -m cibuildwheel --output-dir wheelhouse 
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/upload-to-test-pypi.yml
+++ b/.github/workflows/upload-to-test-pypi.yml
@@ -32,7 +32,8 @@ jobs:
       run: twine check dist/*
 
   build_wheels:
-    if: contains(github.event.head_commit.message, '[upload-to-test-pypi]')
+    # TODO: uncomment the following line after testing
+    # if: contains(github.event.head_commit.message, '[upload-to-test-pypi]')
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/upload-to-test-pypi.yml
+++ b/.github/workflows/upload-to-test-pypi.yml
@@ -32,8 +32,7 @@ jobs:
       run: twine check dist/*
 
   build_wheels:
-    # TODO: uncomment the following line after testing
-    # if: contains(github.event.head_commit.message, '[upload-to-test-pypi]')
+    if: contains(github.event.head_commit.message, '[upload-to-test-pypi]')
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
Closes #6.

This PR adds support for building wheels for aarch64 (arm 64) for linux.

The only downside I can see is that due to emulation, each arm linux build takes approximately 300s, so about 1200s (20 minutes) total extra time for the build.


## Testing

Demo of usage in docker on macOS with an M3 chip (arm64 based):

1. Download artifacts from test run: https://github.com/neuronostics/rocket-fft/actions/runs/7450533530
1. Start container: `docker run -it --entrypoint bash -v ~/Downloads/artifact:/artifact python:3.11` 
1. Install correct wheel `pip install /artifact/rocket_fft-0.2.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl`
1.  Run a test file:
    ```
    root@355ff7fa867a:/# cat test.py 
    import numba as nb
    import numpy as np
    
    @nb.njit
    def jit_fft(x):
        return np.fft.fft(x)
    
    a = np.array([1, 6, 1, 8, 0, 3, 3, 9])
    print(jit_fft(a))
    
    root@355ff7fa867a:/# pip freeze
    llvmlite==0.41.1
    numba==0.58.1
    numpy==1.26.3
    rocket-fft @ file:///artifact/rocket_fft-0.2.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl#sha256=5cfa60c34480522ca3181ab3c35647630477a5280d58f8ef0dde612fd4341107
    root@355ff7fa867a:/# uname -a
    Linux 355ff7fa867a 6.5.11-linuxkit #1 SMP PREEMPT Wed Dec  6 17:08:31 UTC 2023 aarch64 GNU/Linux
    root@355ff7fa867a:/# python test.py
    [ 31.        -0.j           3.82842712+0.58578644j
      -3.        +8.j          -1.82842712-3.41421356j
     -21.        -0.j          -1.82842712+3.41421356j
      -3.        -8.j           3.82842712-0.58578644j]
    ```
